### PR TITLE
Fixed get_optics, command returns unicode instead of float

### DIFF
--- a/napalm_mos/mos.py
+++ b/napalm_mos/mos.py
@@ -617,26 +617,39 @@ class MOSDriver(NetworkDriver):
 
             # Defaulting avg, min, max values to 0.0 since device does not
             # return these values
+            
+            try:
+                rxpwr = float(port_values['rxPwr'])
+            except:
+                rxpwr = 0.0
+
+            try:
+                txpwr = float(port_values['txPwr'])
+            except:
+                txpwr = 0.0
+
+            try:
+                txbias = float(port_values['txBias'])
+            except:
+                txbias = 0.0
+
             optic_states = {
                 'index': 0,
                 'state': {
                     'input_power': {
-                        'instant': (port_values['rxPwr']
-                                    if isinstance(port_values.get("rxPwr"), float) else 0.0),
+                        'instant': rxpwr,
                         'avg': 0.0,
                         'min': 0.0,
                         'max': 0.0
                     },
                     'output_power': {
-                        'instant': (port_values['txPwr']
-                                    if isinstance(port_values.get("txPwr"), float) else 0.0),
+                        'instant': txpwr,
                         'avg': 0.0,
                         'min': 0.0,
                         'max': 0.0
                     },
                     'laser_bias_current': {
-                        'instant': (port_values['txBias']
-                                    if isinstance(port_values.get("txBias"), float) else 0.0),
+                        'instant': txbias,
                         'avg': 0.0,
                         'min': 0.0,
                         'max': 0.0
@@ -646,7 +659,7 @@ class MOSDriver(NetworkDriver):
 
             port_detail['physical_channels']['channel'].append(optic_states)
             optics_detail[port] = port_detail
-
+        
         return optics_detail
 
     def get_config(self, retrieve="all"):

--- a/napalm_mos/mos.py
+++ b/napalm_mos/mos.py
@@ -617,20 +617,19 @@ class MOSDriver(NetworkDriver):
 
             # Defaulting avg, min, max values to 0.0 since device does not
             # return these values
-            
             try:
                 rxpwr = float(port_values['rxPwr'])
-            except:
+            except ValueError:
                 rxpwr = 0.0
 
             try:
                 txpwr = float(port_values['txPwr'])
-            except:
+            except ValueError:
                 txpwr = 0.0
 
             try:
                 txbias = float(port_values['txBias'])
-            except:
+            except ValueError:
                 txbias = 0.0
 
             optic_states = {
@@ -659,7 +658,6 @@ class MOSDriver(NetworkDriver):
 
             port_detail['physical_channels']['channel'].append(optic_states)
             optics_detail[port] = port_detail
-        
         return optics_detail
 
     def get_config(self, retrieve="all"):


### PR DESCRIPTION
Code was broken due to MOS returning results as unicode instead of float.
Using try except blocks make it work despite of changes on how the results are returned.

