### PR TITLE
Change speed type in get_interfaces from int to float

### DIFF
--- a/napalm_mos/mos.py
+++ b/napalm_mos/mos.py
@@ -338,13 +338,13 @@ class MOSDriver(NetworkDriver):
         def _parse_mm_speed(speed):
             """Parse the Metamako speed string from 'sh int status' into an Mbit/s int"""
 
-            factormap = {"": 1e-6, "k": 1e-3, "M": 1, "G": 1e3, "T": 1e6}
+            factormap = {"": 1e-6, "k": 1e-3, "M": 1.0, "G": 1e3, "T": 1e6}
             match = re.match(r"^(?P<speed>\d+)(?P<unit>\D)?$", speed)
             if match:
                 match_dict = match.groupdict("")
-                return int(int(match_dict["speed"]) * factormap[match_dict["unit"]])
+                return float(match_dict["speed"]) * factormap[match_dict["unit"]]
 
-            return 0
+            return 0.0
 
         commands = ["show interfaces status", "show interfaces description"]
         output = self.device.run_commands(commands, encoding="json")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-napalm>=3.3.0
+napalm>=3.4.0
 pyeapi>=0.8.1

--- a/test/unit/mocked_data/test_get_interfaces/normal/expected_result.json
+++ b/test/unit/mocked_data/test_get_interfaces/normal/expected_result.json
@@ -5,7 +5,7 @@
     "last_flapped": 0,
     "is_up": true,
     "mac_address": "",
-    "speed": 10000,
+    "speed": 10000.0,
     "mtu": -1
   },
   "et3": {
@@ -14,7 +14,7 @@
     "last_flapped": 0,
     "is_up": false,
     "mac_address": "",
-    "speed": 0,
+    "speed": 0.0,
     "mtu": -1
   },
   "et1": {
@@ -23,7 +23,7 @@
     "last_flapped": 0,
     "is_up": true,
     "mac_address": "",
-    "speed": 10000,
+    "speed": 10000.0,
     "mtu": -1
   },
   "et6": {
@@ -32,7 +32,7 @@
     "last_flapped": 0,
     "is_up": false,
     "mac_address": "",
-    "speed": 0,
+    "speed": 0.0,
     "mtu": -1
   },
   "et7": {
@@ -41,7 +41,7 @@
     "last_flapped": 0,
     "is_up": false,
     "mac_address": "",
-    "speed": 0,
+    "speed": 0.0,
     "mtu": -1
   },
   "et4": {
@@ -50,7 +50,7 @@
     "last_flapped": 0,
     "is_up": false,
     "mac_address": "",
-    "speed": 0,
+    "speed": 0.0,
     "mtu": -1
   },
   "et5": {
@@ -59,7 +59,7 @@
     "last_flapped": 0,
     "is_up": false,
     "mac_address": "",
-    "speed": 0,
+    "speed": 0.0,
     "mtu": -1
   },
   "et8": {
@@ -68,7 +68,7 @@
     "last_flapped": 0,
     "is_up": false,
     "mac_address": "",
-    "speed": 0,
+    "speed": 0.0,
     "mtu": -1
   },
   "et9": {
@@ -77,7 +77,7 @@
     "last_flapped": 0,
     "is_up": false,
     "mac_address": "",
-    "speed": 0,
+    "speed": 0.0,
     "mtu": -1
   },
   "et16": {
@@ -86,7 +86,7 @@
     "last_flapped": 0,
     "is_up": false,
     "mac_address": "",
-    "speed": 0,
+    "speed": 0.0,
     "mtu": -1
   },
   "et14": {
@@ -95,7 +95,7 @@
     "last_flapped": 0,
     "is_up": false,
     "mac_address": "",
-    "speed": 0,
+    "speed": 0.0,
     "mtu": -1
   },
   "et15": {
@@ -104,7 +104,7 @@
     "last_flapped": 0,
     "is_up": false,
     "mac_address": "",
-    "speed": 0,
+    "speed": 0.0,
     "mtu": -1
   },
   "ma1": {
@@ -113,7 +113,7 @@
     "last_flapped": 0,
     "is_up": true,
     "mac_address": "",
-    "speed": 1000,
+    "speed": 1000.0,
     "mtu": -1
   },
   "et10": {
@@ -122,7 +122,7 @@
     "last_flapped": 0,
     "is_up": false,
     "mac_address": "",
-    "speed": 0,
+    "speed": 0.0,
     "mtu": -1
   },
   "et11": {
@@ -131,7 +131,7 @@
     "last_flapped": 0,
     "is_up": false,
     "mac_address": "",
-    "speed": 0,
+    "speed": 0.0,
     "mtu": -1
   },
   "et12": {
@@ -140,7 +140,7 @@
     "last_flapped": 0,
     "is_up": false,
     "mac_address": "",
-    "speed": 0,
+    "speed": 0.0,
     "mtu": -1
   },
   "et13": {
@@ -149,7 +149,7 @@
     "last_flapped": 0,
     "is_up": false,
     "mac_address": "",
-    "speed": 0,
+    "speed": 0.0,
     "mtu": -1
   }
 }

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
-envlist = py{36,37,38}-napalm{3.3.0}
+envlist = py{36,37,38}-napalm{3.4.0}
 
 [travis:env]
 NAPALM =
-    3.3.0: napalm3.3.0
+    3.4.0: napalm3.4.0
 
 [testenv]
 deps =
-    napalm3.3.0: napalm==3.3.0
+    napalm3.4.0: napalm==3.4.0
     -rrequirements-dev.txt
 passenv = NAPALM* TOX*
 


### PR DESCRIPTION
Recently speed type for get_interfaces was changed from int to float in napalm 3.4.0:
https://github.com/napalm-automation/napalm/issues/1459

Do the same change for napalm-mos.